### PR TITLE
Combined Ansible and Terraform runtime

### DIFF
--- a/runtime/ansible_terraform/Dockerfile
+++ b/runtime/ansible_terraform/Dockerfile
@@ -1,0 +1,37 @@
+#
+#  Onix Config Manager - Artisan Runtime Image - Terraform & Ansible combination image
+#  Copyright (c) 2018-2021 by www.gatblau.org
+#  Licensed under the Apache License, Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Contributors to this project, hereby assign copyright in this code to the project,
+#  to be licensed under the same terms as the rest of the code.
+#
+
+# NB. This is a specific image for an edge case where:
+#   1. The image needs to be as small as possible (hence Alpine not ubi-min)
+#   2. Both Terraform and Ansible installed in the same image (again to cut down on download requirements)
+#   3. Allow UID/GID to be over-ridden if required
+
+FROM alpine
+ENV TERRAFORM_VERSION=1.0.7
+ENV UID=256000
+ENV GID=256000
+
+WORKDIR /app/
+
+USER root
+
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    chmod +x terraform && \
+    mv terraform /usr/local/bin/. && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+RUN apk --no-cache add ansible
+
+ARG UNAME=runtime
+
+RUN addgroup -g $GID -S $UNAME && \
+    adduser -u $UID -S $UNAME -G $UNAME
+
+USER $UNAME

--- a/runtime/ansible_terraform/README.md
+++ b/runtime/ansible_terraform/README.md
@@ -1,0 +1,5 @@
+# ansible_terraform Artisan runtime
+This is a specific image for an edge case where:
+1. The image needs to be as small as possible (hence Alpine not ubi-min)
+2. Both Terraform and Ansible installed in the same image (again to cut down on download requirements)
+3. Allow UID/GID to be over-ridden if required

--- a/runtime/ansible_terraform/build.yaml
+++ b/runtime/ansible_terraform/build.yaml
@@ -1,0 +1,26 @@
+---
+env:
+  REPO_NAME: quay.io/artisan
+  IMG_NAME: ansible_terraform
+  ART_PACKAGE: artisan
+
+functions:
+  - name: build
+    description: builds and push docker image
+    run:
+      - docker build -t=${REPO_NAME}/${IMG_NAME}:${ARTISAN_REF} .
+      - docker tag ${REPO_NAME}/${IMG_NAME}:${ARTISAN_REF} ${REPO_NAME}/${IMG_NAME}:latest
+
+  - name: push
+    description: builds and push docker image
+    run:
+      - docker push ${REPO_NAME}/${IMG_NAME}:${ARTISAN_REF}
+      - docker push ${REPO_NAME}/${IMG_NAME}:latest
+
+  - name: version
+    description: prints the versions for the tools in this runtime
+    runtime: ansible_terraform
+    run:
+      - terraform --version
+      - ansible -v
+...


### PR DESCRIPTION
Normally runtimes are focused on single application or technology - but this is a specific image for an edge case where:

1. The image needs to be as small as possible (hence Alpine not ubi-min)
2. Both Terraform and Ansible installed in the same image (again to cut down on download requirements)
3. Allow UID/GID to be over-ridden if required

Not sure if this meets the "criteria" for Artisan but I think it would be useful?

NB. Thinking of Edge solutions where absolute minimum download size may well be important